### PR TITLE
ENH: Implement local running interface

### DIFF
--- a/bqcloud/api.py
+++ b/bqcloud/api.py
@@ -4,11 +4,13 @@ import os
 import urllib.request
 import typing
 from typing import Any, Dict, List, Optional, Type
+import warnings
 
 from .annealing import AnnealingTask, AnnealingResult
 from .data import ExecutionRequest, ExecutionRequestEncoder, Status, TaskData, TaskListData
 from .device import Device
 from .task import Task, TaskIter, TaskList
+from .local import make_localtask
 
 from .datafactory import make_executiondata, make_result
 
@@ -87,6 +89,10 @@ class Api:
                 group: Optional[str] = None,
                 send_email: bool = False) -> Task:
         """Create new task and execute the task."""
+        if device.value == 'local':
+            if group is not None or send_email:
+                warnings.warn('Arguments `group` and `send_email` is ignored in local device.')
+            return make_localtask(c, shots)
         execdata = make_executiondata(c, device, shots, group, send_email)
         return self.post_executiondata(execdata)
 

--- a/bqcloud/device.py
+++ b/bqcloud/device.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class Device(str, Enum):
+    Local = "local"
     IonQDevice = "aws/ionq/ionQdevice"
     Aspen8 = "aws/rigetti/Aspen-8"
     Aspen9 = "aws/rigetti/Aspen-9"

--- a/bqcloud/local.py
+++ b/bqcloud/local.py
@@ -1,0 +1,38 @@
+"""For local task."""
+
+import typing
+from typing import Optional
+
+from blueqat import Circuit
+
+from .abstract_result import AbstractResult
+from .data import Status
+from .task import Task
+
+class LocalResult(AbstractResult):
+    def __init__(self, shots: typing.Counter[str]):
+        self._shots = shots
+
+    def shots(self) -> typing.Counter[str]:
+        return self._shots
+
+class LocalTask(Task):
+    """Task for local simulator."""
+    def __init__(self, circuit: Circuit, result: LocalResult) -> None:
+        self.circuit = circuit
+        self.result = result
+
+    def status(self) -> Status:
+        return Status.COMPLETED
+
+    def update(self) -> None:
+        pass
+
+    def __repr__(self) -> str:
+        return f'LocalTask({self.circuit}, {self.result})'
+
+    def wait(self, timeout: int = 0) -> Optional[AbstractResult]:
+        return self.result
+
+def make_localtask(c: Circuit, shots: int):
+    return LocalTask(c, LocalResult(c.copy().m[:].run(shots=shots)))


### PR DESCRIPTION
closes #1 

```py
from bqcloud import load_api, Device
from blueqat import Circuit

api = load_api()
task = api.execute(Circuit().h[0], Device.Local, 1000)
result = task.wait()

print(result.shots())
```

In this implementation, the circuit is calculated when `api.execute` is called.
However, this behavior may be changed in the future.